### PR TITLE
Remove unnecessary mirrors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["bevy", "rapier", "bevy-inspector-egui"]
 categories = ["game-development"]
 repository = "https://github.com/devildahu/bevy_mod_component_mirror"
 exclude = ["assets", ".github", "Makefile"]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [features]

--- a/Readme.md
+++ b/Readme.md
@@ -45,8 +45,6 @@ syncs its value with it.
 
 - `ImpulseJoint`
 - `Collider` (**some collider shape are not implemented yet!**)
-- `ColliderMassProperties`
-- `AdditionalMassProperties`
 
 ### Implement your own mirrors
 

--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,7 @@ to find the right physics parameters.
 
 ```toml
 [dependencies]
-bevy_mod_component_mirror = "0.11.0"
+bevy_mod_component_mirror = "0.12.0"
 ```
 
 2. Add `RapierMirrorsPlugins` to your app
@@ -106,7 +106,7 @@ you can disable the rapier components with:
 
 ```toml
 [dependencies]
-bevy_mod_component_mirror = { version = "0.11.0", default-features = false }
+bevy_mod_component_mirror = { version = "0.12.0", default-features = false }
 ```
 
 ## Version matrix
@@ -114,13 +114,14 @@ bevy_mod_component_mirror = { version = "0.11.0", default-features = false }
 
 | bevy | bevy_rapier3d | bevy_mod_component_mirror |
 |------|---------------|---------------------------|
-| 0.12 | 0.23.0 | 0.11.0 |
+| 0.12 | 0.23.0 | 0.11.0, 0.12.0 |
 | 0.11 | 0.22.0 | 0.10.0 |
 | 0.10 | 0.21.0 | 0.9 |
 | 0.9  | 0.20.0 | 0.7 |
 
 ## Change log
 
+* `0.12`: **BREAKING**: Removes Components that Bevy Rapier already reflects (ColliderMassProperties, AdditionalMassProperties, MassProperties)
 * `0.11`: **BREAKING**: Bump to bevy 0.12 & rapier 0.23
 * `0.10`: **BREAKING**: Bump to bevy 0.11 & rapier 0.22 (Thanks Naomijub on GitHub, See #3)
 * `0.9`: Fix a compilation error which source is currently unknown

--- a/src/rapier_mirrors.rs
+++ b/src/rapier_mirrors.rs
@@ -2,10 +2,7 @@ mod collider;
 mod impulse_joint;
 
 use crate::MirrorPlugin;
-use bevy::{
-    app::PluginGroupBuilder,
-    prelude::{Plugin, PluginGroup},
-};
+use bevy::prelude::Plugin;
 use bevy_rapier3d::prelude::{
     AdditionalMassProperties, Collider, ColliderMassProperties, ImpulseJoint,
 };
@@ -58,13 +55,14 @@ impl Plugin for AdditionalReflectionsPlugin {
     }
 }
 
-impl PluginGroup for RapierMirrorsPlugins {
-    fn build(self) -> PluginGroupBuilder {
-        PluginGroupBuilder::start::<Self>()
-            .add(AdditionalMassPropertiesMirrorPlugin::new())
-            .add(ColliderMassPropertiesMirrorPlugin::new())
-            .add(ColliderMirrorPlugin::new())
-            .add(ImpulseJointMirrorPlugin::new())
-            .add(AdditionalReflectionsPlugin)
+impl Plugin for RapierMirrorsPlugins {
+    fn build(&self, app: &mut bevy::prelude::App) {
+        app
+            .add_plugins((
+                AdditionalMassPropertiesMirrorPlugin::new(),
+                ColliderMassPropertiesMirrorPlugin::new(),
+                ColliderMirrorPlugin::new(),
+                ImpulseJointMirrorPlugin::new(),
+                AdditionalReflectionsPlugin));
     }
 }

--- a/src/rapier_mirrors.rs
+++ b/src/rapier_mirrors.rs
@@ -2,7 +2,10 @@ mod collider;
 mod impulse_joint;
 
 use crate::MirrorPlugin;
-use bevy::prelude::Plugin;
+use bevy::{
+    app::PluginGroupBuilder,
+    prelude::{Plugin, PluginGroup},
+};
 use bevy_rapier3d::prelude::{Collider, ImpulseJoint};
 
 pub use collider::ColliderMirror;
@@ -47,12 +50,11 @@ impl Plugin for AdditionalReflectionsPlugin {
     }
 }
 
-impl Plugin for RapierMirrorsPlugins {
-    fn build(&self, app: &mut bevy::prelude::App) {
-        app.add_plugins((
-            ColliderMirrorPlugin::new(),
-            ImpulseJointMirrorPlugin::new(),
-            AdditionalReflectionsPlugin,
-        ));
+impl PluginGroup for RapierMirrorsPlugins {
+    fn build(self) -> PluginGroupBuilder {
+        PluginGroupBuilder::start::<Self>()
+            .add(ColliderMirrorPlugin::new())
+            .add(ImpulseJointMirrorPlugin::new())
+            .add(AdditionalReflectionsPlugin)
     }
 }

--- a/src/rapier_mirrors.rs
+++ b/src/rapier_mirrors.rs
@@ -3,11 +3,9 @@ mod impulse_joint;
 
 use crate::MirrorPlugin;
 use bevy::prelude::Plugin;
-use bevy_rapier3d::prelude::{
-    AdditionalMassProperties, Collider, ColliderMassProperties, ImpulseJoint,
-};
+use bevy_rapier3d::prelude::{Collider, ImpulseJoint};
 
-pub use collider::{AdditionalMassPropertiesMirror, ColliderMassPropertiesMirror, ColliderMirror};
+pub use collider::ColliderMirror;
 pub use impulse_joint::ImpulseJointMirror;
 
 use self::{
@@ -17,10 +15,6 @@ use self::{
 
 pub type ImpulseJointMirrorPlugin = MirrorPlugin<ImpulseJoint, ImpulseJointMirror>;
 pub type ColliderMirrorPlugin = MirrorPlugin<Collider, ColliderMirror>;
-pub type ColliderMassPropertiesMirrorPlugin =
-    MirrorPlugin<ColliderMassProperties, ColliderMassPropertiesMirror>;
-pub type AdditionalMassPropertiesMirrorPlugin =
-    MirrorPlugin<AdditionalMassProperties, AdditionalMassPropertiesMirror>;
 
 /// Add components mirroring non-reflect rapier components.
 ///
@@ -40,8 +34,6 @@ pub type AdditionalMassPropertiesMirrorPlugin =
 ///
 /// - `ImpulseJoint`
 /// - `Collider` (**some collider shape are not implemented yet!**)
-/// - `ColliderMassProperties`
-/// - `AdditionalMassProperties`
 pub struct RapierMirrorsPlugins;
 
 struct AdditionalReflectionsPlugin;
@@ -57,12 +49,10 @@ impl Plugin for AdditionalReflectionsPlugin {
 
 impl Plugin for RapierMirrorsPlugins {
     fn build(&self, app: &mut bevy::prelude::App) {
-        app
-            .add_plugins((
-                AdditionalMassPropertiesMirrorPlugin::new(),
-                ColliderMassPropertiesMirrorPlugin::new(),
-                ColliderMirrorPlugin::new(),
-                ImpulseJointMirrorPlugin::new(),
-                AdditionalReflectionsPlugin));
+        app.add_plugins((
+            ColliderMirrorPlugin::new(),
+            ImpulseJointMirrorPlugin::new(),
+            AdditionalReflectionsPlugin,
+        ));
     }
 }

--- a/src/rapier_mirrors/collider.rs
+++ b/src/rapier_mirrors/collider.rs
@@ -1,9 +1,6 @@
 use bevy::prelude::*;
 use bevy_rapier3d::{
-    prelude::{
-        AdditionalMassProperties, Collider, ColliderMassProperties,
-        MassProperties as RapierMassProperties,
-    },
+    prelude::Collider,
     rapier::prelude::{RoundShape, Shape as RapierShape, SharedShape},
     rapier::{
         parry::shape,
@@ -265,84 +262,5 @@ impl<'a> From<&'a ColliderMirror> for SharedShape {
 impl Mirror<Collider> for ColliderMirror {
     fn apply(&self, val: &mut Collider) {
         val.raw = self.into();
-    }
-}
-#[derive(Clone, Reflect, Debug)]
-pub struct MassProps {
-    pub local_center_of_mass: Vec3,
-    pub mass: f32,
-    pub principal_inertia: Vec3,
-    pub inertia_local_frame: Quat,
-}
-
-impl MassProps {
-    const fn into_rapier(&self) -> RapierMassProperties {
-        RapierMassProperties {
-            local_center_of_mass: self.local_center_of_mass,
-            mass: self.mass,
-            principal_inertia_local_frame: self.inertia_local_frame,
-            principal_inertia: self.principal_inertia,
-        }
-    }
-}
-#[derive(Clone, Reflect, Debug, Component)]
-pub enum AdditionalMassPropertiesMirror {
-    Mass(f32),
-    Props(MassProps),
-}
-
-#[derive(Clone, Reflect, Debug, Component)]
-pub enum ColliderMassPropertiesMirror {
-    Density(f32),
-    Mass(f32),
-    Props(MassProps),
-}
-
-impl<'a> From<&'a RapierMassProperties> for MassProps {
-    fn from(value: &'a RapierMassProperties) -> Self {
-        Self {
-            local_center_of_mass: value.local_center_of_mass,
-            mass: value.mass,
-            principal_inertia: value.principal_inertia,
-            inertia_local_frame: value.principal_inertia_local_frame,
-        }
-    }
-}
-impl<'a> From<&'a AdditionalMassProperties> for AdditionalMassPropertiesMirror {
-    fn from(value: &'a AdditionalMassProperties) -> Self {
-        use AdditionalMassProperties as Rapier;
-        match value {
-            Rapier::Mass(mass) => Self::Mass(*mass),
-            Rapier::MassProperties(props) => Self::Props(props.into()),
-        }
-    }
-}
-impl<'a> From<&'a ColliderMassProperties> for ColliderMassPropertiesMirror {
-    fn from(value: &'a ColliderMassProperties) -> Self {
-        use ColliderMassProperties as Rapier;
-        match value {
-            Rapier::Density(value) => Self::Density(*value),
-            Rapier::Mass(value) => Self::Mass(*value),
-            Rapier::MassProperties(value) => Self::Props(value.into()),
-        }
-    }
-}
-impl Mirror<AdditionalMassProperties> for AdditionalMassPropertiesMirror {
-    fn apply(&self, val: &mut AdditionalMassProperties) {
-        use AdditionalMassProperties as Rapier;
-        *val = match self {
-            Self::Mass(value) => Rapier::Mass(*value),
-            Self::Props(value) => Rapier::MassProperties(value.into_rapier()),
-        };
-    }
-}
-impl Mirror<ColliderMassProperties> for ColliderMassPropertiesMirror {
-    fn apply(&self, val: &mut ColliderMassProperties) {
-        use ColliderMassProperties as Rapier;
-        *val = match self {
-            Self::Density(value) => Rapier::Density(*value),
-            Self::Mass(value) => Rapier::Mass(*value),
-            Self::Props(value) => Rapier::MassProperties(value.into_rapier()),
-        };
     }
 }


### PR DESCRIPTION
Rapier has already introduced reflect for:
- [MassProperties]( https://github.com/dimforge/bevy_rapier/blob/fdf71724f1ac45c1fe26d0e67ba41c52b960407c/src/dynamics/rigid_body.rs#L217)
- [ColliderMassProperties](https://github.com/dimforge/bevy_rapier/blob/fdf71724f1ac45c1fe26d0e67ba41c52b960407c/src/geometry/collider.rs#L123)
- [AdditionalMassProperties](https://github.com/dimforge/bevy_rapier/blob/fdf71724f1ac45c1fe26d0e67ba41c52b960407c/src/dynamics/rigid_body.rs#L156)

Having their plugins can make the system feel bloated 